### PR TITLE
Add Hebrew Translation

### DIFF
--- a/locales/he.lua
+++ b/locales/he.lua
@@ -1,0 +1,12 @@
+Locales['he'] = {
+  ['invoices'] = 'חשבוניות',
+  ['invoices_item'] = '%s₪',
+  ['received_invoice'] = 'אתה עכשיו ~r~קיבלת חשבונית',
+  ['paid_invoice'] = 'שילמת חשבונית של ~r~%s₪',
+  ['no_invoices'] = 'אין לך אף חשבונות לשלם',
+  ['received_payment'] = 'קיבלת תשלום בסך ~r~%s₪',
+  ['player_not_online'] = 'השחקן לא מחובר',
+  ['no_money'] = 'אין לך מספיק כסף כדי לשלם את חשבונית זאת',
+  ['target_no_money'] = 'לשחקן ~r~אין מספיק כסף כדי לשלם את החשבונית!',
+  ['keymap_showbills'] = 'פתח תפריט חשבוניות',
+}


### PR DESCRIPTION
Fluent Hebrew Translation to give Israeli players the best experience with esx-billing.
Additional changes in this version:
Currency change from USD to ILS ($ -> ₪)
Text Altering for Hebrew readers
Different placing of placeholders
Provided by FiveM Israel with the mission to translate popular FiveM scripts to Hebrew!